### PR TITLE
feat: handle fmt.Sprintf as second argument where string is expected

### DIFF
--- a/pkgerrors/pkgerrors.go
+++ b/pkgerrors/pkgerrors.go
@@ -238,6 +238,9 @@ func reorderArgs(exprs []ast.Expr) []ast.Expr {
 		if r.Fun.(*ast.SelectorExpr).Sel.Name == "Sprintf" {
 			s = r.Args[0].(*ast.BasicLit).Value
 		}
+		if len(r.Args) > 1 {
+			args = append(r.Args[1:], args...)
+		}
 	default:
 		panic(fmt.Sprintf("not sure what to do with type %T", msg))
 	}

--- a/pkgerrors/testdata/src/a/errors.go
+++ b/pkgerrors/testdata/src/a/errors.go
@@ -96,6 +96,11 @@ func PkgErrorsWrap3() (any, struct{}, error) {
 	return nil, struct{}{}, errors.Wrap(cause, "oh noes") // want `found use location of the deprecated github.com/pkg/errors`
 }
 
+func PkgErrorsWrap4() (any, struct{}, error) {
+	cause := errors.New("whoops")
+	return nil, struct{}{}, errors.Wrap(cause, fmt.Sprintf("oh noes: %s", "yeah")) // want `found use location of the deprecated github.com/pkg/errors`
+}
+
 func PkgErrorsWrapf() error {
 	cause := errors.New("whoops")
 	return errors.Wrapf(cause, "oh noes #%d", 1) // want `found use location of the deprecated github.com/pkg/errors`
@@ -109,4 +114,9 @@ func PkgErrorsWrapf2() (any, error) {
 func PkgErrorsWrapf3() (any, struct{}, error) {
 	cause := errors.New("whoops")
 	return nil, struct{}{}, errors.Wrapf(cause, "oh noes #%d", 3) // want `found use location of the deprecated github.com/pkg/errors`
+}
+
+func PkgErrorsWrapf4() (any, struct{}, error) {
+	cause := errors.New("whoops")
+	return nil, struct{}{}, errors.Wrapf(cause, fmt.Sprintf("oh noes #%d", 3)) // want `found use location of the deprecated github.com/pkg/errors`
 }

--- a/pkgerrors/testdata/src/a/errors.go.golden
+++ b/pkgerrors/testdata/src/a/errors.go.golden
@@ -96,6 +96,11 @@ func PkgErrorsWrap3() (any, struct{}, error) {
 	return nil, struct{}{}, fmt.Errorf("oh noes: %w", cause) // want `found use location of the deprecated github.com/pkg/errors`
 }
 
+func PkgErrorsWrap4() (any, struct{}, error) {
+	cause := errors.New("whoops")
+	return nil, struct{}{}, fmt.Errorf("oh noes: %s: %w", "yeah", cause) // want `found use location of the deprecated github.com/pkg/errors`
+}
+
 func PkgErrorsWrapf() error {
 	cause := errors.New("whoops")
 	return fmt.Errorf("oh noes #%d: %w", 1, cause) // want `found use location of the deprecated github.com/pkg/errors`
@@ -107,6 +112,11 @@ func PkgErrorsWrapf2() (any, error) {
 }
 
 func PkgErrorsWrapf3() (any, struct{}, error) {
+	cause := errors.New("whoops")
+	return nil, struct{}{}, fmt.Errorf("oh noes #%d: %w", 3, cause) // want `found use location of the deprecated github.com/pkg/errors`
+}
+
+func PkgErrorsWrapf4() (any, struct{}, error) {
 	cause := errors.New("whoops")
 	return nil, struct{}{}, fmt.Errorf("oh noes #%d: %w", 3, cause) // want `found use location of the deprecated github.com/pkg/errors`
 }


### PR DESCRIPTION
Handle fmt.Sprintf as the second argument to "WithMessage", "WithMessagef", "Wrap", "Wrapf"